### PR TITLE
Don't use immutable yarn install after modifying lockfile for patched lockfile

### DIFF
--- a/.github/workflows/abq-release.yml
+++ b/.github/workflows/abq-release.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Point to @rwx-research versions of patched packages
         run: node scripts/abqPrepare.mjs
       - name: Update lockfile for patched versions
-        run: yarn
+        run: yarn --no-immutable
       - name: Build
         run: yarn build
       - name: Publish @rwx-research/jest-runner


### PR DESCRIPTION
It looks like a `yarn --immutable` will persist for future `yarn` runs. We specifically don't want that when running a release.

See [failed build job](https://github.com/rwx-research/jest/actions/runs/3878180248/jobs/6614073187).