### PR TITLE
Test same build logic in CI as release.

### DIFF
--- a/.github/workflows/abq-release.yml
+++ b/.github/workflows/abq-release.yml
@@ -37,12 +37,10 @@ jobs:
           cache: yarn
       - name: Install dependencies
         run: yarn --immutable
-      - name: Point to @rwx-research versions of patched packages
-        run: node scripts/abqPrepare.mjs
-      - name: Update lockfile for patched versions
-        run: yarn --no-immutable
       - name: Build
         run: yarn build
+      - name: Point to @rwx-research versions of patched packages
+        run: node scripts/abqPrepare.mjs
       - name: Publish @rwx-research/jest-runner
         working-directory: packages/jest-runner
         run: yarn npm publish

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -107,21 +107,26 @@ jobs:
         run: yarn dedupe --check
 
   yarn-build:
-    name: Build
+    name: Build Jest for ABQ
     runs-on: ubuntu-latest
     needs: prepare-yarn-cache-ubuntu
     steps:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
-      - uses: actions/setup-node@v3
+      - name: Set up node.js
+        uses: actions/setup-node@v3
         with:
           node-version: lts/*
+          registry-url: https://registry.npmjs.org
+          scope: '@rwx-research'
           cache: yarn
-      - name: install
+      - name: Install dependencies
         run: yarn --immutable
-      - name: Build with yarn
+      - name: Build
         run: yarn build
+      - name: Point to @rwx-research versions of patched packages
+        run: node scripts/abqPrepare.mjs
 
   test-ubuntu:
     uses: ./.github/workflows/test.yml

--- a/package.json
+++ b/package.json
@@ -173,12 +173,15 @@
     "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
   },
   "resolutions": {
+    "@jest/core": "workspace:^",
     "@types/node": "~14.14.45",
     "ansi-escapes/type-fest": "^2.0.0",
     "babel-jest": "workspace:^",
     "enzyme/cheerio": "=1.0.0-rc.3",
     "jest": "workspace:^",
-    "jest-environment-node": "workspace:^"
+    "jest-config": "workspace:^",
+    "jest-environment-node": "workspace:^",
+    "jest-runner": "workspace:^"
   },
   "packageManager": "yarn@3.2.4"
 }

--- a/scripts/abqPrepare.mjs
+++ b/scripts/abqPrepare.mjs
@@ -18,7 +18,6 @@ import * as path from 'path';
 import chalk from 'chalk';
 import {
   absolutePackagePath,
-  absoluteProjectPath,
   ensureVersionsCompatible,
   packages,
   version,
@@ -39,19 +38,6 @@ packages.forEach(pkg => {
     packageJson.name = pkg.rwxName;
     packageJson.version = version;
 
-    // Translate dependencies like
-    //   "jest-config": "workspace:^"
-    // to
-    //   "jest-config": "npm:@rwx-research/jest-config@<version>"
-    packages.forEach(({upstreamName, rwxName}) => {
-      if (upstreamName in packageJson.dependencies) {
-        console.assert(
-          packageJson.dependencies[upstreamName].startsWith('workspace'),
-        );
-        packageJson.dependencies[upstreamName] = `npm:${rwxName}@${version}`;
-      }
-    });
-
     fs.writeFileSync(
       packageJsonPath,
       `${JSON.stringify(packageJson, null, 2)}\n`,
@@ -63,16 +49,3 @@ packages.forEach(pkg => {
     throw err;
   }
 });
-
-const rootPackageJsonPath = path.join(absoluteProjectPath(), 'package.json');
-const rootPackageJson = require(rootPackageJsonPath);
-packages.forEach(({upstreamName, path: packagePath}) => {
-  rootPackageJson.resolutions[upstreamName] = `file:./packages/${packagePath}`;
-});
-
-fs.writeFileSync(
-  rootPackageJsonPath,
-  `${JSON.stringify(rootPackageJson, null, 2)}\n`,
-);
-
-console.log('Updated resolutions in package.json');


### PR DESCRIPTION
Follow-up to #21, which didn't actually fix anything in CI, only locally. I was able to reproduce the release-via-CI issue only when blasting all local hidden changes (eg. `git clean -xfd`).

Included is running `yarn build` as we do for release during CI to try to catch this in the future.

Instead of updating the `package.json` for each custom package during the `abqPrepare` stage, we can lean on dynamic resolution of npm/yarn to find the appropriate package. We don't change the source code to import from `jest-runner` to `@rwx-research/jest-runner`, that's handled by `overrides`/`resolutions` in the consuming project's `package.json`. As such, we don't need to change these dependencies at compile/publish time - if the consuming project doesn't provide all of the proper overrides, the imports wouldn't work as expected anyway.