### PR TITLE
Update release steps and release v29.3.100-alpha.6

### DIFF
--- a/.github/workflows/abq-release.yml
+++ b/.github/workflows/abq-release.yml
@@ -41,6 +41,8 @@ jobs:
         run: yarn build
       - name: Point to @rwx-research versions of patched packages
         run: node scripts/abqPrepare.mjs
+      - name: Update local dependencies for ABQ
+        run: yarn --no-immutable
       - name: Publish @rwx-research/jest-runner
         working-directory: packages/jest-runner
         run: yarn npm publish

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -127,6 +127,8 @@ jobs:
         run: yarn build
       - name: Point to @rwx-research versions of patched packages
         run: node scripts/abqPrepare.mjs
+      - name: Update local dependencies for ABQ
+        run: yarn --no-immutable
 
   test-ubuntu:
     uses: ./.github/workflows/test.yml

--- a/README.rwx.md
+++ b/README.rwx.md
@@ -13,9 +13,10 @@ Commit the version change.
 Get a fresh checkout. Then, in order:
 
 ```
-node scripts/abqPrepare.mjs   # set rwx-exposed versions of abq-patched jest packages
-yarn         # update the lockfile to point to rwx-exposed versions
-yarn build   # set rwx-exposed versions of abq-patched jest packages
+yarn
+yarn build
+node scripts/abqPrepare.mjs
+yarn
 
 # For each rwx-published package, IN ORDER:
 #  packages/jest-runner

--- a/abq.json
+++ b/abq.json
@@ -1,5 +1,5 @@
 {
-  "version": "29.3.100-alpha.5",
+  "version": "29.3.100-alpha.6",
   "packages": [
     {
       "path": "jest-config",

--- a/scripts/abqPrepare.mjs
+++ b/scripts/abqPrepare.mjs
@@ -18,6 +18,7 @@ import * as path from 'path';
 import chalk from 'chalk';
 import {
   absolutePackagePath,
+  absoluteProjectPath,
   ensureVersionsCompatible,
   packages,
   version,
@@ -38,6 +39,19 @@ packages.forEach(pkg => {
     packageJson.name = pkg.rwxName;
     packageJson.version = version;
 
+    // Translate dependencies like
+    //   "jest-config": "workspace:^"
+    // to
+    //   "jest-config": "npm:@rwx-research/jest-config@<version>"
+    packages.forEach(({upstreamName, rwxName}) => {
+      if (upstreamName in packageJson.dependencies) {
+        console.assert(
+          packageJson.dependencies[upstreamName].startsWith('workspace'),
+        );
+        packageJson.dependencies[upstreamName] = `npm:${rwxName}@${version}`;
+      }
+    });
+
     fs.writeFileSync(
       packageJsonPath,
       `${JSON.stringify(packageJson, null, 2)}\n`,
@@ -49,3 +63,16 @@ packages.forEach(pkg => {
     throw err;
   }
 });
+
+const rootPackageJsonPath = path.join(absoluteProjectPath(), 'package.json');
+const rootPackageJson = require(rootPackageJsonPath);
+packages.forEach(({upstreamName, path: packagePath}) => {
+  rootPackageJson.resolutions[upstreamName] = `file:./packages/${packagePath}`;
+});
+
+fs.writeFileSync(
+  rootPackageJsonPath,
+  `${JSON.stringify(rootPackageJson, null, 2)}\n`,
+);
+
+console.log('Updated resolutions in package.json');


### PR DESCRIPTION
The previous PRs didn't work for both local dev and package release. Reverts part of #22.

I've made it end-to-end on this now, manually releasing v29.3.100-alpha.5 with these steps. The sample repo has also been bumped to alpha.5 and [passes CI](https://github.com/rwx-research/abq-jest-integration-example/actions/runs/3888066138/jobs/6635014126).