### PR TITLE
Set up .yarnrc.yml for release workflow and release v29.3.100-alpha.7

### DIFF
--- a/.github/workflows/abq-release.yml
+++ b/.github/workflows/abq-release.yml
@@ -35,6 +35,14 @@ jobs:
           registry-url: https://registry.npmjs.org
           scope: '@rwx-research'
           cache: yarn
+          always-auth: true
+      - name: Setup .yarnrc.yml
+        run: |
+          yarn config set npmScopes.rwx-research.npmRegistryServer "https://registry.yarnpkg.com"
+          yarn config set npmScopes.rwx-research.npmAlwaysAuth true
+          yarn config set npmScopes.rwx-research.npmAuthToken "${NODE_AUTH_TOKEN}"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
       - name: Install dependencies
         run: yarn --immutable
       - name: Build

--- a/.github/workflows/abq-release.yml
+++ b/.github/workflows/abq-release.yml
@@ -38,7 +38,6 @@ jobs:
           always-auth: true
       - name: Setup .yarnrc.yml
         run: |
-          yarn config set npmScopes.rwx-research.npmRegistryServer "https://registry.yarnpkg.com"
           yarn config set npmScopes.rwx-research.npmAlwaysAuth true
           yarn config set npmScopes.rwx-research.npmAuthToken "${NODE_AUTH_TOKEN}"
         env:

--- a/abq.json
+++ b/abq.json
@@ -1,5 +1,5 @@
 {
-  "version": "29.3.100-alpha.6",
+  "version": "29.3.100-alpha.7",
   "packages": [
     {
       "path": "jest-config",


### PR DESCRIPTION
Publishing packages with Yarn2 is [advanced usage](https://github.com/actions/setup-node/blob/f38519bb96e0c6850682026afd9d5f1708c15e8f/docs/advanced-usage.md#yarn2-configuration) for the `setup-node` action (despite eg. caching with yarn2 not being advanced usage). 🤷 

This code powered the [release of `alpha.6` outside of our normal release process](https://github.com/rwx-research/jest/actions/runs/3889464545/jobs/6637740047), since I couldn't take another failed partial PR fix.