### PR TITLE
Correct calculation of test runtime

### DIFF
--- a/e2e/__tests__/__snapshots__/abq.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/abq.test.ts.snap
@@ -252,6 +252,7 @@ Array [
          |                ^
       11 | });
       12 |
+      13 | test('this test is also failing', () => {
 
       at Object.toBe (__tests__/failing.test.js:10:16)
 ",
@@ -259,6 +260,44 @@ Array [
       "status": Object {
         "backtrace": Array [
           "at Object.toBe (<<REPLACED>>/e2e/abq/__tests__/failing.test.js:10:16)",
+        ],
+        "exception": "expect(received).toBe(expected) // Object.is equality
+
+Expected: false
+Received: true",
+        "type": "failure",
+      },
+    },
+    Object {
+      "display_name": "this test is also failing",
+      "id": "this test is also failing",
+      "lineage": Array [],
+      "location": Object {
+        "column": 1,
+        "file": "<<REPLACED>>/e2e/abq/__tests__/failing.test.js",
+        "line": 13,
+      },
+      "meta": Object {},
+      "output": "  ● this test is also failing
+
+    expect(received).toBe(expected) // Object.is equality
+
+    Expected: false
+    Received: true
+
+      12 |
+      13 | test('this test is also failing', () => {
+    > 14 |   expect(true).toBe(false);
+         |                ^
+      15 | });
+      16 |
+
+      at Object.toBe (__tests__/failing.test.js:14:16)
+",
+      "runtime": 12,
+      "status": Object {
+        "backtrace": Array [
+          "at Object.toBe (<<REPLACED>>/e2e/abq/__tests__/failing.test.js:14:16)",
         ],
         "exception": "expect(received).toBe(expected) // Object.is equality
 

--- a/e2e/abq/__tests__/failing.test.js
+++ b/e2e/abq/__tests__/failing.test.js
@@ -9,3 +9,7 @@
 test('this test is failing', () => {
   expect(true).toBe(false);
 });
+
+test('this test is also failing', () => {
+  expect(true).toBe(false);
+});

--- a/e2e/abqUtils.ts
+++ b/e2e/abqUtils.ts
@@ -85,6 +85,7 @@ export function filterTestResultForSnapshot(testResults: Array<TestResult>) {
 }
 
 export function filterTestResultsForSnapshotHelp(testResult: TestResult) {
+  console.assert(testResult.runtime > 0);
   const result = {
     ...testResult,
     display_name: replacePath(testResult.display_name),

--- a/packages/jest-circus/src/eventHandler.ts
+++ b/packages/jest-circus/src/eventHandler.ts
@@ -194,19 +194,19 @@ const eventHandler: Circus.EventHandler = async (event, state) => {
       break;
     }
     case 'test_skip': {
-      event.test.duration = getTestDuration(event.test);
       event.test.durationNanos = getNanosDuration(event.test);
       event.test.status = 'skip';
       if (state.abqSocket) {
+        event.test.duration = getTestDuration(event.test);
         await sendAbqTest(state, event.test);
       }
       break;
     }
     case 'test_todo': {
-      event.test.duration = getTestDuration(event.test);
       event.test.durationNanos = getNanosDuration(event.test);
       event.test.status = 'todo';
       if (state.abqSocket) {
+        event.test.duration = getTestDuration(event.test);
         await sendAbqTest(state, event.test);
       }
       break;

--- a/packages/jest-circus/src/utils.ts
+++ b/packages/jest-circus/src/utils.ts
@@ -72,6 +72,7 @@ export const makeTest = (
   asyncError,
   concurrent,
   duration: null,
+  durationNanos: null,
   errors: [],
   failing,
   fn,
@@ -82,6 +83,7 @@ export const makeTest = (
   retryReasons: [],
   seenDone: false,
   startedAt: null,
+  startedAtNanos: null,
   status: null,
   timeout,
 });
@@ -310,6 +312,16 @@ export const callAsyncCircusFn = (
 export const getTestDuration = (test: Circus.TestEntry): number | null => {
   const {startedAt} = test;
   return typeof startedAt === 'number' ? Date.now() - startedAt : null;
+};
+
+export const nanosNow = (): number => {
+  const [seconds, nanos] = process.hrtime();
+  return seconds * 1_000_000_000 + nanos;
+};
+
+export const getNanosDuration = (test: Circus.TestEntry): number => {
+  const {startedAtNanos} = test;
+  return nanosNow() - startedAtNanos!;
 };
 
 export const makeRunResult = (

--- a/packages/jest-runner/src/index.ts
+++ b/packages/jest-runner/src/index.ts
@@ -200,7 +200,7 @@ export default class TestRunner extends EmittingTestRunner {
                   };
                 } else {
                   const estimatedRuntime = millisecondToNanosecond(
-                    estimatedStartTime - Date.now(),
+                    Date.now() - estimatedStartTime,
                   );
 
                   const formattedError = formatExecError(

--- a/packages/jest-types/src/Circus.ts
+++ b/packages/jest-types/src/Circus.ts
@@ -257,7 +257,12 @@ export type TestEntry = {
   name: TestName;
   parent: DescribeBlock;
   startedAt?: number | null;
+  /** NOTE: uses process.hrtime. Not suitable for measuring epoch time, or in
+   * non-node environments!
+   */
+  startedAtNanos: number | null;
   duration?: number | null;
+  durationNanos: number | null;
   seenDone: boolean;
   status?: TestStatus | null; // whether the test has been skipped or run already
   timeout?: number;


### PR DESCRIPTION
- Fixes an arithmetic bug in calculating test runtime
- Uses a high-resolution timer for calculating runtime in jest-circus, up to nanosecond resolution. This means our fork of jest-circus can only be used in Node, but ABQ can only be used in node anyway.