### PR TITLE
Report unique test ID to ABQ as test location and index in describe block

### DIFF
--- a/abq.json
+++ b/abq.json
@@ -1,5 +1,5 @@
 {
-  "version": "29.4.100",
+  "version": "29.4.101",
   "packages": [
     {
       "path": "jest-config",

--- a/e2e/__tests__/__snapshots__/abq.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/abq.test.ts.snap
@@ -5,14 +5,14 @@ Array [
   Array [
     Object {
       "display_name": "looper i == i",
-      "id": "__tests__/looped.test.js@3:5#0",
+      "id": "__tests__/looped.test.js@11:5#0",
       "lineage": Array [
         "looper",
       ],
       "location": Object {
         "column": 5,
         "file": "<<REPLACED>>/e2e/abq/__tests__/looped.test.js",
-        "line": 3,
+        "line": 11,
       },
       "meta": Object {},
       "output": null,
@@ -23,14 +23,14 @@ Array [
     },
     Object {
       "display_name": "looper i == i",
-      "id": "__tests__/looped.test.js@3:5#1",
+      "id": "__tests__/looped.test.js@11:5#1",
       "lineage": Array [
         "looper",
       ],
       "location": Object {
         "column": 5,
         "file": "<<REPLACED>>/e2e/abq/__tests__/looped.test.js",
-        "line": 3,
+        "line": 11,
       },
       "meta": Object {},
       "output": null,
@@ -41,14 +41,14 @@ Array [
     },
     Object {
       "display_name": "looper i == i",
-      "id": "__tests__/looped.test.js@3:5#2",
+      "id": "__tests__/looped.test.js@11:5#2",
       "lineage": Array [
         "looper",
       ],
       "location": Object {
         "column": 5,
         "file": "<<REPLACED>>/e2e/abq/__tests__/looped.test.js",
-        "line": 3,
+        "line": 11,
       },
       "meta": Object {},
       "output": null,
@@ -59,14 +59,14 @@ Array [
     },
     Object {
       "display_name": "looper i == i",
-      "id": "__tests__/looped.test.js@3:5#3",
+      "id": "__tests__/looped.test.js@11:5#3",
       "lineage": Array [
         "looper",
       ],
       "location": Object {
         "column": 5,
         "file": "<<REPLACED>>/e2e/abq/__tests__/looped.test.js",
-        "line": 3,
+        "line": 11,
       },
       "meta": Object {},
       "output": null,
@@ -77,14 +77,14 @@ Array [
     },
     Object {
       "display_name": "looper i == i",
-      "id": "__tests__/looped.test.js@3:5#4",
+      "id": "__tests__/looped.test.js@11:5#4",
       "lineage": Array [
         "looper",
       ],
       "location": Object {
         "column": 5,
         "file": "<<REPLACED>>/e2e/abq/__tests__/looped.test.js",
-        "line": 3,
+        "line": 11,
       },
       "meta": Object {},
       "output": null,

--- a/e2e/__tests__/__snapshots__/abq.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/abq.test.ts.snap
@@ -5,12 +5,12 @@ Array [
   Array [
     Object {
       "display_name": "looper i == i",
-      "id": "__tests__/looped.test.js@3:7#0",
+      "id": "__tests__/looped.test.js@3:5#0",
       "lineage": Array [
         "looper",
       ],
       "location": Object {
-        "column": 7,
+        "column": 5,
         "file": "<<REPLACED>>/e2e/abq/__tests__/looped.test.js",
         "line": 3,
       },
@@ -23,12 +23,12 @@ Array [
     },
     Object {
       "display_name": "looper i == i",
-      "id": "__tests__/looped.test.js@3:7#1",
+      "id": "__tests__/looped.test.js@3:5#1",
       "lineage": Array [
         "looper",
       ],
       "location": Object {
-        "column": 7,
+        "column": 5,
         "file": "<<REPLACED>>/e2e/abq/__tests__/looped.test.js",
         "line": 3,
       },
@@ -41,12 +41,12 @@ Array [
     },
     Object {
       "display_name": "looper i == i",
-      "id": "__tests__/looped.test.js@3:7#2",
+      "id": "__tests__/looped.test.js@3:5#2",
       "lineage": Array [
         "looper",
       ],
       "location": Object {
-        "column": 7,
+        "column": 5,
         "file": "<<REPLACED>>/e2e/abq/__tests__/looped.test.js",
         "line": 3,
       },
@@ -59,12 +59,12 @@ Array [
     },
     Object {
       "display_name": "looper i == i",
-      "id": "__tests__/looped.test.js@3:7#3",
+      "id": "__tests__/looped.test.js@3:5#3",
       "lineage": Array [
         "looper",
       ],
       "location": Object {
-        "column": 7,
+        "column": 5,
         "file": "<<REPLACED>>/e2e/abq/__tests__/looped.test.js",
         "line": 3,
       },
@@ -77,12 +77,12 @@ Array [
     },
     Object {
       "display_name": "looper i == i",
-      "id": "__tests__/looped.test.js@3:7#4",
+      "id": "__tests__/looped.test.js@3:5#4",
       "lineage": Array [
         "looper",
       ],
       "location": Object {
-        "column": 7,
+        "column": 5,
         "file": "<<REPLACED>>/e2e/abq/__tests__/looped.test.js",
         "line": 3,
       },

--- a/e2e/__tests__/__snapshots__/abq.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/abq.test.ts.snap
@@ -1,11 +1,108 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ABQ handles ID generation for tests in loops 1`] = `
+Array [
+  Array [
+    Object {
+      "display_name": "looper i == i",
+      "id": "__tests__/looped.test.js@3:7#0",
+      "lineage": Array [
+        "looper",
+      ],
+      "location": Object {
+        "column": 7,
+        "file": "<<REPLACED>>/e2e/abq/__tests__/looped.test.js",
+        "line": 3,
+      },
+      "meta": Object {},
+      "output": null,
+      "runtime": 12,
+      "status": Object {
+        "type": "success",
+      },
+    },
+    Object {
+      "display_name": "looper i == i",
+      "id": "__tests__/looped.test.js@3:7#1",
+      "lineage": Array [
+        "looper",
+      ],
+      "location": Object {
+        "column": 7,
+        "file": "<<REPLACED>>/e2e/abq/__tests__/looped.test.js",
+        "line": 3,
+      },
+      "meta": Object {},
+      "output": null,
+      "runtime": 12,
+      "status": Object {
+        "type": "success",
+      },
+    },
+    Object {
+      "display_name": "looper i == i",
+      "id": "__tests__/looped.test.js@3:7#2",
+      "lineage": Array [
+        "looper",
+      ],
+      "location": Object {
+        "column": 7,
+        "file": "<<REPLACED>>/e2e/abq/__tests__/looped.test.js",
+        "line": 3,
+      },
+      "meta": Object {},
+      "output": null,
+      "runtime": 12,
+      "status": Object {
+        "type": "success",
+      },
+    },
+    Object {
+      "display_name": "looper i == i",
+      "id": "__tests__/looped.test.js@3:7#3",
+      "lineage": Array [
+        "looper",
+      ],
+      "location": Object {
+        "column": 7,
+        "file": "<<REPLACED>>/e2e/abq/__tests__/looped.test.js",
+        "line": 3,
+      },
+      "meta": Object {},
+      "output": null,
+      "runtime": 12,
+      "status": Object {
+        "type": "success",
+      },
+    },
+    Object {
+      "display_name": "looper i == i",
+      "id": "__tests__/looped.test.js@3:7#4",
+      "lineage": Array [
+        "looper",
+      ],
+      "location": Object {
+        "column": 7,
+        "file": "<<REPLACED>>/e2e/abq/__tests__/looped.test.js",
+        "line": 3,
+      },
+      "meta": Object {},
+      "output": null,
+      "runtime": 12,
+      "status": Object {
+        "type": "success",
+      },
+    },
+  ],
+]
+`;
+
 exports[`ABQ mode handles errors in a test 1`] = `
 Array [
   Array [
     Object {
       "display_name": "this test is erroring",
-      "id": "this test is erroring",
+      "id": "__tests__/errors.test.js@9:1#0",
       "lineage": Array [],
       "location": Object {
         "column": 1,
@@ -85,7 +182,7 @@ Array [
   Array [
     Object {
       "display_name": "one skipped test",
-      "id": "one skipped test",
+      "id": "__tests__/skip.test.js@9:6#0",
       "lineage": Array [],
       "location": Object {
         "column": 6,
@@ -101,7 +198,7 @@ Array [
     },
     Object {
       "display_name": "other skipped test",
-      "id": "other skipped test",
+      "id": "__tests__/skip.test.js@11:6#1",
       "lineage": Array [],
       "location": Object {
         "column": 6,
@@ -124,7 +221,7 @@ Array [
   Array [
     Object {
       "display_name": "one todo test",
-      "id": "one todo test",
+      "id": "__tests__/todo.test.js@9:6#0",
       "lineage": Array [],
       "location": Object {
         "column": 6,
@@ -140,7 +237,7 @@ Array [
     },
     Object {
       "display_name": "other todo test",
-      "id": "other todo test",
+      "id": "__tests__/todo.test.js@11:6#1",
       "lineage": Array [],
       "location": Object {
         "column": 6,
@@ -197,6 +294,14 @@ Array [
           "type": "test",
         },
         Object {
+          "id": "__tests__/looped.test.js",
+          "meta": Object {
+            "fileName": "__tests__/looped.test.js",
+          },
+          "tags": Array [],
+          "type": "test",
+        },
+        Object {
           "id": "__tests__/skip.test.js",
           "meta": Object {
             "fileName": "__tests__/skip.test.js",
@@ -231,7 +336,7 @@ Array [
   Array [
     Object {
       "display_name": "this test is failing",
-      "id": "this test is failing",
+      "id": "__tests__/failing.test.js@9:1#0",
       "lineage": Array [],
       "location": Object {
         "column": 1,
@@ -270,7 +375,7 @@ Received: true",
     },
     Object {
       "display_name": "this test is also failing",
-      "id": "this test is also failing",
+      "id": "__tests__/failing.test.js@13:1#1",
       "lineage": Array [],
       "location": Object {
         "column": 1,
@@ -310,7 +415,7 @@ Received: true",
   Array [
     Object {
       "display_name": "the + operator 1 + 2 equals 3",
-      "id": "the + operator 1 + 2 equals 3",
+      "id": "__tests__/sum.test.js@10:3#0",
       "lineage": Array [
         "the + operator",
       ],
@@ -328,7 +433,7 @@ Received: true",
     },
     Object {
       "display_name": "the + operator 2 + 3 equals 5",
-      "id": "the + operator 2 + 3 equals 5",
+      "id": "__tests__/sum.test.js@14:3#1",
       "lineage": Array [
         "the + operator",
       ],
@@ -346,7 +451,7 @@ Received: true",
     },
     Object {
       "display_name": "the + operator with three operands 2 + 3 + 4 equals 9",
-      "id": "the + operator with three operands 2 + 3 + 4 equals 9",
+      "id": "__tests__/sum.test.js@19:5#0",
       "lineage": Array [
         "the + operator",
         "with three operands",
@@ -372,7 +477,7 @@ Array [
   Array [
     Object {
       "display_name": "the + operator 1 + 2 equals 3",
-      "id": "the + operator 1 + 2 equals 3",
+      "id": "__tests__/sum.test.js@10:3#0",
       "lineage": Array [
         "the + operator",
       ],
@@ -390,7 +495,7 @@ Array [
     },
     Object {
       "display_name": "the + operator 2 + 3 equals 5",
-      "id": "the + operator 2 + 3 equals 5",
+      "id": "__tests__/sum.test.js@14:3#1",
       "lineage": Array [
         "the + operator",
       ],
@@ -408,7 +513,7 @@ Array [
     },
     Object {
       "display_name": "the + operator with three operands 2 + 3 + 4 equals 9",
-      "id": "the + operator with three operands 2 + 3 + 4 equals 9",
+      "id": "__tests__/sum.test.js@19:5#0",
       "lineage": Array [
         "the + operator",
         "with three operands",

--- a/e2e/__tests__/__snapshots__/circusDeclarationErrors.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/circusDeclarationErrors.test.ts.snap
@@ -16,7 +16,7 @@ exports[`defining tests and hooks asynchronously throws 1`] = `
       14 |   });
       15 | });
 
-      at eventHandler (../../packages/jest-circus/build/eventHandler.js:177:11)
+      at eventHandler (../../packages/jest-circus/build/eventHandler.js:178:11)
       at test (__tests__/asyncDefinition.test.js:12:5)
 
   ● Test suite failed to run
@@ -31,7 +31,7 @@ exports[`defining tests and hooks asynchronously throws 1`] = `
       15 | });
       16 |
 
-      at eventHandler (../../packages/jest-circus/build/eventHandler.js:140:11)
+      at eventHandler (../../packages/jest-circus/build/eventHandler.js:141:11)
       at afterAll (__tests__/asyncDefinition.test.js:13:5)
 
   ● Test suite failed to run
@@ -46,7 +46,7 @@ exports[`defining tests and hooks asynchronously throws 1`] = `
       20 | });
       21 |
 
-      at eventHandler (../../packages/jest-circus/build/eventHandler.js:177:11)
+      at eventHandler (../../packages/jest-circus/build/eventHandler.js:178:11)
       at test (__tests__/asyncDefinition.test.js:18:3)
 
   ● Test suite failed to run
@@ -60,6 +60,6 @@ exports[`defining tests and hooks asynchronously throws 1`] = `
       20 | });
       21 |
 
-      at eventHandler (../../packages/jest-circus/build/eventHandler.js:140:11)
+      at eventHandler (../../packages/jest-circus/build/eventHandler.js:141:11)
       at afterAll (__tests__/asyncDefinition.test.js:19:3)"
 `;

--- a/e2e/__tests__/abq.test.ts
+++ b/e2e/__tests__/abq.test.ts
@@ -295,3 +295,30 @@ ctest('ABQ mode handles todo tests', async () => {
     },
   );
 });
+
+ctest('ABQ handles ID generation for tests in loops', async () => {
+  expect.assertions(1);
+
+  const [socketString, getMessages] = await spawnServer([
+    {
+      id: pathForAbqTestFile('looped.test.js'),
+      meta: {
+        fileName: pathForAbqTestFile('looped.test.js'),
+      },
+      tags: [],
+      type: 'test',
+    },
+  ]);
+
+  await runAbqJest(
+    {
+      ABQ_SOCKET: socketString,
+    },
+    async () => {
+      const serverMessages = (await getMessages()).map(
+        filterTestResultForSnapshot,
+      );
+      expect(serverMessages).toMatchSnapshot();
+    },
+  );
+});

--- a/e2e/abq/__tests__/looped.test.js
+++ b/e2e/abq/__tests__/looped.test.js
@@ -1,0 +1,7 @@
+describe('looper', () => { 
+    for(let i = 0; i < 5; i++){
+      it('i == i', () => {
+        expect(i).toBe(i);
+      });
+    }
+});

--- a/e2e/abq/__tests__/looped.test.js
+++ b/e2e/abq/__tests__/looped.test.js
@@ -1,7 +1,7 @@
-describe('looper', () => { 
-    for(let i = 0; i < 5; i++){
-      it('i == i', () => {
-        expect(i).toBe(i);
-      });
-    }
+describe('looper', () => {
+  for (let i = 0; i < 5; i++) {
+    it('i == i', () => {
+      expect(i).toBe(i);
+    });
+  }
 });

--- a/e2e/abq/__tests__/looped.test.js
+++ b/e2e/abq/__tests__/looped.test.js
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) ReadWriteExecute, Inc. and its affiliates. All Rights Reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 describe('looper', () => {
   for (let i = 0; i < 5; i++) {
     it('i == i', () => {

--- a/packages/jest-circus/src/run.ts
+++ b/packages/jest-circus/src/run.ts
@@ -119,7 +119,7 @@ function collectConcurrentTests(
     return [];
   }
   const {hasFocusedTests, testNamePattern} = getState();
-  return describeBlock.children.flatMap(child => {
+  return describeBlock.children.flatMap((child, index) => {
     switch (child.type) {
       case 'describeBlock':
         return collectConcurrentTests(child);
@@ -129,6 +129,7 @@ function collectConcurrentTests(
           child.mode === 'skip' ||
           (hasFocusedTests && child.mode !== 'only') ||
           (testNamePattern && !testNamePattern.test(getTestID(child)));
+        child.indexInParent = index;
         return skip
           ? []
           : [child as Circus.TestEntry & {fn: Circus.ConcurrentTestFn}];

--- a/packages/jest-circus/src/run.ts
+++ b/packages/jest-circus/src/run.ts
@@ -119,7 +119,7 @@ function collectConcurrentTests(
     return [];
   }
   const {hasFocusedTests, testNamePattern} = getState();
-  return describeBlock.children.flatMap((child, index) => {
+  return describeBlock.children.flatMap(child => {
     switch (child.type) {
       case 'describeBlock':
         return collectConcurrentTests(child);
@@ -129,7 +129,6 @@ function collectConcurrentTests(
           child.mode === 'skip' ||
           (hasFocusedTests && child.mode !== 'only') ||
           (testNamePattern && !testNamePattern.test(getTestID(child)));
-        child.indexInParent = index;
         return skip
           ? []
           : [child as Circus.TestEntry & {fn: Circus.ConcurrentTestFn}];

--- a/packages/jest-circus/src/utils.ts
+++ b/packages/jest-circus/src/utils.ts
@@ -77,6 +77,7 @@ export const makeTest = (
   errors: [],
   failing,
   fn,
+  indexInParent,
   invocations: 0,
   mode,
   name: convertDescriptorToString(name),

--- a/packages/jest-circus/src/utils.ts
+++ b/packages/jest-circus/src/utils.ts
@@ -64,6 +64,7 @@ export const makeTest = (
   concurrent: boolean,
   name: Circus.TestName,
   parent: Circus.DescribeBlock,
+  indexInParent: number,
   timeout: number | undefined,
   asyncError: Circus.Exception,
   failing: boolean,

--- a/packages/jest-types/src/Circus.ts
+++ b/packages/jest-types/src/Circus.ts
@@ -252,6 +252,11 @@ export type TestEntry = {
   errors: Array<TestError>;
   retryReasons: Array<TestError>;
   fn: TestFn;
+  /**
+   * The index of this test in its encompassing parent block.
+   * Used to disambiguate tests at the same location.
+   */
+  indexInParent: number;
   invocations: number;
   mode: TestMode;
   concurrent: boolean;


### PR DESCRIPTION
ABQ expects these test IDs to be unique - prior to this patch, they were not necessarily, as they only contained the display name of the test. In this patch we make the test ID unique by listing its file path, location in the file, and its index in the parent describe block. The latter is needed to uniquely identify tests that occur at the same location.

To deal with different paths between filesystems, make the path relative to the root directory.